### PR TITLE
Added acceptableContentTypes Override

### DIFF
--- a/RSSParser/RSSParser.m
+++ b/RSSParser/RSSParser.m
@@ -62,7 +62,9 @@
 + (NSSet *)defaultAcceptableContentTypes {
     return [NSSet setWithObjects:@"application/xml", @"text/xml",@"application/rss+xml", nil];
 }
-
++ (NSSet *)acceptableContentTypes {
+    return [self defaultAcceptableContentTypes];
+}
 #pragma mark -
 
 #pragma mark NSXMLParser delegate


### PR DESCRIPTION
AFNetworking seems to be using the acceptableContentTypes method, instead of the defaultAcceptableContentTypes
