### PR TITLE
[Podspec] Allow AFNetworking minor versions

### DIFF
--- a/BlockRSSParser.podspec
+++ b/BlockRSSParser.podspec
@@ -17,5 +17,5 @@ Pod::Spec.new do |s|
 
   s.source_files = 'Classes', 'RSSParser/*.{h,m}'
 
-  s.dependency 'AFNetworking', '~> 2.0.3'
+  s.dependency 'AFNetworking', '~> 2.0'
 end


### PR DESCRIPTION
AFNetworking is properly versioned so there should be no issues in supporting all the 2.x versions.
