### PR TITLE
Set currentItem to nil when elemnetName is item or entry

### DIFF
--- a/RSSParser/RSSParser.m
+++ b/RSSParser/RSSParser.m
@@ -78,6 +78,7 @@
 {    
     if ([elementName isEqualToString:@"item"] || [elementName isEqualToString:@"entry"]) {
         [items addObject:currentItem];
+        currentItem = nil;
     }
     if (currentItem != nil && tmpString != nil) {
         


### PR DESCRIPTION
When the element name is item or entry and there are parameters like title, link, description etc outside item after that, the item child nodes are replaced with that parameters or added that parameter if there is no item child notes. Like the following xml.
<channel>
		<item>
		<title>item title</title>
		<link>item URL</link>
		<description>item content</description>
		<dc:subject>item category</dc:subject>
		<dc:creator>item auther</dc:creator> 
		<dc:date>item date</dc:date>
		</item>

		<title>site title</title>
		<link>site RSS URL</link>
		<description>site content</description>
		<dc:language>en</dc:language>
		<dc:creator>site owner</dc:creator>
		<dc:date>RSS last updated date</dc:date>
</channel>