### PR TITLE
performance optimizations

### DIFF
--- a/RSSParser/RSSParser.h
+++ b/RSSParser/RSSParser.h
@@ -13,6 +13,7 @@
     RSSItem *currentItem;
     NSMutableArray *items;
     NSMutableString *tmpString;
+    NSDictionary *tmpAttrDict;
     void (^block)(NSArray *feedItems);
     void (^failblock)(NSError *error);
 }

--- a/RSSParser/RSSParser.m
+++ b/RSSParser/RSSParser.m
@@ -80,6 +80,7 @@
     }
     
     tmpString = [[NSMutableString alloc] init];
+    tmpAttrDict = attributeDict;
 }
 
 - (void)parser:(NSXMLParser *)parser didEndElement:(NSString *)elementName namespaceURI:(NSString *)namespaceURI qualifiedName:(NSString *)qName {
@@ -108,6 +109,14 @@
             [currentItem setAuthor:tmpString];
         } else if ([elementName isEqualToString:@"guid"]) {
             [currentItem setGuid:tmpString];
+        }
+        
+        // sometimes the URL is inside enclosure element, not in link. Reference: http://www.w3schools.com/rss/rss_tag_enclosure.asp
+        if ([elementName isEqualToString:@"enclosure"] && tmpAttrDict != nil) {
+            NSString *url = [tmpAttrDict objectForKey:@"url"];
+            if(url) {
+                [currentItem setLink:[NSURL URLWithString:url]];
+            }
         }
     }
     


### PR DESCRIPTION
This pull has the following optimizations:

1) Creating an NSDateFormatter is expensive and is not necessary for each item (see: http://stackoverflow.com/questions/8832768/why-is-allocating-or-initializing-nsdateformatter-considered-expensive)

2) There's no need to keep comparing strings when we've already found our match. 